### PR TITLE
Removed reconnecting for client when connection to AMQP is down.

### DIFF
--- a/lib/protein/amqp_adapter.rb
+++ b/lib/protein/amqp_adapter.rb
@@ -116,8 +116,7 @@ class AMQPAdapter
     def prepare_client
       return if @conn
 
-      @conn = Bunny.new(url)
-      @conn.start
+      connect_bunny
       @ch = @conn.create_channel
       @x = @ch.default_exchange
       @server_queue = queue
@@ -133,6 +132,14 @@ class AMQPAdapter
           that.lock.synchronize{that.condition.signal}
         end
       end
+    end
+
+    def connect_bunny
+      @conn = Bunny.new(url, recover_from_connection_close: false)
+      @conn.start
+    rescue Bunny::TCPConnectionFailedForAllHosts
+      @conn = nil
+      raise
     end
   end
 end

--- a/lib/protein/version.rb
+++ b/lib/protein/version.rb
@@ -1,3 +1,3 @@
 module Protein
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
Before this change the client would keep reconnecting (until request timeout). Now `Bunny` is configured with `recover_from_connection_close` flag in order not to retry connection.
Connection will still be triggered by the next RPC action.