### PR TITLE
Fix AMQP server prefetch

### DIFF
--- a/lib/protein/amqp_adapter.rb
+++ b/lib/protein/amqp_adapter.rb
@@ -72,6 +72,7 @@ class AMQPAdapter
       @conn = Bunny.new(url)
       @conn.start
       @ch = @conn.create_channel
+      @ch.prefetch(1)
       @q = @ch.queue(queue)
       @x = @ch.default_exchange
 


### PR DESCRIPTION
https://shedul.atlassian.net/browse/ID-7965

This is an outcome from [RPC benchmark](https://shedul.atlassian.net/wiki/spaces/SHED/pages/472318039/RPC+RabbitMQ+vs+HTTP+v2). It fixes load balancing among RPC server processes.