### PR TITLE
Fix AMQP client multithreading

### DIFF
--- a/lib/protein/amqp_adapter.rb
+++ b/lib/protein/amqp_adapter.rb
@@ -55,7 +55,7 @@ class AMQPAdapter
       call[:condition] = condition
       calls[call_id] = call
 
-      lock.synchronize { condition.wait(lock, timeout && timeout * 0.001) }
+      mutex.synchronize { condition.wait(mutex, timeout && timeout * 0.001) }
 
       response = call[:response]
       calls.delete(call_id)

--- a/lib/protein/amqp_adapter.rb
+++ b/lib/protein/amqp_adapter.rb
@@ -139,11 +139,9 @@ class AMQPAdapter
         if call
           mutex = call[:mutex]
           condition = call[:condition]
+          call[:response] = payload
 
-          if mutex && condition
-            call[:response] = payload
-            mutex.synchronize { condition.signal }
-          end
+          mutex.synchronize { condition.signal }
         end
       end
     end

--- a/lib/protein/amqp_adapter.rb
+++ b/lib/protein/amqp_adapter.rb
@@ -130,6 +130,7 @@ class AMQPAdapter
       @x = @ch.default_exchange
       @server_queue = queue
       @reply_queue = @ch.queue("", exclusive: true)
+      @calls = Concurrent::Hash.new
 
       @reply_queue.subscribe do |delivery_info, properties, payload|
         call_id = properties[:correlation_id]

--- a/protein.gemspec
+++ b/protein.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bunny', '~> 2.0', '>= 2.0.0'
 
+  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0', '>= 1.0.5'
   spec.add_runtime_dependency 'google-protobuf', '~> 3.0', '>= 3.0.0'
   spec.add_runtime_dependency 'parallel', '~> 1.0', '>= 1.0.0'
 end


### PR DESCRIPTION
Original implementation assumed single-threaded usage. This is not true in cases like Puma multithreading or Sidekiq. This implementation allows to safely make client calls in multiple threads, routing incoming responses to each of them.

An isolated test suite for this issue and solution prototype may be found here: https://github.com/surgeventures/rpc-client-ruby-threadsafe.