### PR TITLE
Fixed raising error in amqp_adapter.

### DIFF
--- a/lib/protein/amqp_adapter.rb
+++ b/lib/protein/amqp_adapter.rb
@@ -112,7 +112,7 @@ class AMQPAdapter
             @ch.ack(delivery_info.delivery_tag)
             if @error
               log_error(@error)
-              raise(message)
+              raise(@error)
             end
           end
         rescue StandardError => e


### PR DESCRIPTION
## Overview
This PR fixes raising error in `amqp_adapter.rb`.