### PR TITLE
Add on_worker_boot callback support to server

### DIFF
--- a/lib/protein/server.rb
+++ b/lib/protein/server.rb
@@ -31,10 +31,12 @@ class Server
 
     def start
       worker_count = config.fetch(:concurrency, 5)
+      on_worker_boot = config[:on_worker_boot]
 
       if worker_count.is_a?(Integer) && worker_count > 1
         Parallel.each(1..worker_count, in_processes: worker_count) do |worker|
           Protein.logger.info "Starting server #{worker}/#{worker_count} with PID #{Process.pid}"
+          on_worker_boot.call if on_worker_boot.respond_to?(:call)
           transport_class.serve(router)
         end
       else


### PR DESCRIPTION
Adds ability to configure and execute callback after forking the workers. This allows performing initialization before first request is processed - for example it make it possible to establish connection to database before requests are handled.