### PR TITLE
One line request logs

### DIFF
--- a/lib/protein.rb
+++ b/lib/protein.rb
@@ -42,6 +42,7 @@ class << self
     @logger ||= begin
       Logger.new($stdout).tap do |log|
         log.progname = 'protein'
+        log.level = config.log_level || :info
       end
     end
   end

--- a/lib/protein/config.rb
+++ b/lib/protein/config.rb
@@ -1,5 +1,6 @@
 module Protein
   class Config
     attr_accessor :error_logger
+    attr_accessor :log_level
   end
 end

--- a/lib/protein/processor.rb
+++ b/lib/protein/processor.rb
@@ -15,13 +15,13 @@ class Processor
     private
 
     def process_and_log_call(service_name, service_class, request_buf)
-      Protein.logger.info "Processing RPC call: #{service_name}"
-
       start_time = Time.now
       response_buf, errors = process_call(service_class, request_buf)
       duration_ms = ((Time.now - start_time) * 1000).round
 
-      Protein.logger.info "#{response_buf ? 'Resolved' : 'Rejected'} in #{duration_ms}ms"
+      Protein.logger.info(
+        "RPC call #{service_name} #{response_buf ? 'resolved' : 'rejected'} in #{duration_ms}ms"
+      )
 
       Payload::Response.encode(response_buf, errors) if service_class.response?
     end
@@ -44,13 +44,11 @@ class Processor
     end
 
     def process_and_log_push(service_name, service_class, request_buf)
-      Protein.logger.info "Processing RPC push: #{service_name}"
-
       start_time = Time.now
       process_push(service_class, request_buf)
       duration_ms = ((Time.now - start_time) * 1000).round
 
-      Protein.logger.info "Processed in #{duration_ms}ms"
+      Protein.logger.info "RPC push #{service_name} processed in #{duration_ms}ms"
 
       nil
     end


### PR DESCRIPTION
Multi line logs make log reading or querying for stats quite hard, the new format make it slightly better.
Additionally I've added ability to configure log level.

Old format:
```
[2019-06-28T12:48:38.045573 #34] INFO -- protein: Processing RPC call: some_action
[2019-06-28T12:48:38.113198 #54] INFO -- protein: Processing RPC call: another_action
[2019-06-28T12:48:38.083760 #34] INFO -- protein: Resolved in 38ms
[2019-06-28T12:48:38.176725 #37] INFO -- protein: Processing RPC call: another_action
[2019-06-28T12:48:38.197275 #55] INFO -- protein: Processing RPC call: another_action
[2019-06-28T12:48:38.244510 #37] INFO -- protein: Resolved in 68ms
[2019-06-28T12:48:38.262265 #55] INFO -- protein: Resolved in 65ms
[2019-06-28T12:48:38.127635 #57] INFO -- protein: Processing RPC call: more_actions
[2019-06-28T12:48:38.195192 #57] INFO -- protein: Resolved in 67ms
[2019-06-28T12:48:38.212175 #54] INFO -- protein: Resolved in 99ms
```
New Format: 
```
[2019-06-28T12:48:38.083760 #34] INFO -- protein: RPC call some_action resolved in 38ms
[2019-06-28T12:48:38.244510 #37] INFO -- protein: RPC call another_action resolved in 68ms
[2019-06-28T12:48:38.262265 #55] INFO -- protein: RPC call another_action resolved in 65ms
[2019-06-28T12:48:38.195192 #57] INFO -- protein: RPC call more_actions resolved in 67ms
[2019-06-28T12:48:38.212175 #54] INFO -- protein: RPC call another_action resolved in 99ms
```