### PR TITLE
Add optional wrapper to RPC processor

### DIFF
--- a/lib/protein.rb
+++ b/lib/protein.rb
@@ -3,6 +3,8 @@ begin
 rescue LoadError
 end
 
+require "logger"
+
 require "concurrent"
 require "google/protobuf"
 

--- a/lib/protein/router.rb
+++ b/lib/protein/router.rb
@@ -15,7 +15,6 @@ class Router
     end
 
     def config(config = nil)
-      puts "adding #{config} to config of #{self}"
       @config = (@config || {}).merge(config) if config
       @config || {}
     end

--- a/lib/protein/router.rb
+++ b/lib/protein/router.rb
@@ -14,6 +14,12 @@ class Router
       end
     end
 
+    def config(config = nil)
+      puts "adding #{config} to config of #{self}"
+      @config = (@config || {}).merge(config) if config
+      @config || {}
+    end
+
     def from_hash(hash)
       if hash[:services]
         hash[:services].each do |each_service|

--- a/spec/integration/rpc_contract.rb
+++ b/spec/integration/rpc_contract.rb
@@ -26,6 +26,8 @@ module RPC
   end
 
   class Router < Protein::Router
+    config(around_processing: ->(block) { block.call })
+
     service "RPC::TestService"
   end
 end

--- a/spec/integration/rpc_contract.rb
+++ b/spec/integration/rpc_contract.rb
@@ -26,7 +26,9 @@ module RPC
   end
 
   class Router < Protein::Router
-    config(around_processing: ->(block) { block.call })
+    config(around_processing: ->(block, name, klass) do
+      block.call
+    end)
 
     service "RPC::TestService"
   end

--- a/wait-for
+++ b/wait-for
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-TIMEOUT=15
+TIMEOUT=30
 QUIET=0
 
 echoerr() {


### PR DESCRIPTION
In order to monitor RPC servers with APM `Protein::Router` can now be configured to
wrap service call with custom block.